### PR TITLE
Fix margin/padding

### DIFF
--- a/src/element-overlay.ts
+++ b/src/element-overlay.ts
@@ -18,12 +18,16 @@ export default class ElementOverlay {
     this.overlay.style.cursor = options.style?.cursor || "crosshair";
     this.overlay.style.position = options.style?.position || "absolute";
     this.overlay.style.zIndex = options.style?.zIndex || "2147483647";
+    this.overlay.style.margin = options.style?.margin || "0px";
+    this.overlay.style.padding = options.style?.padding || "0px";
 
     this.shadowContainer = document.createElement("div");
     this.shadowContainer.className = "_ext-element-overlay-container";
     this.shadowContainer.style.position = "absolute";
     this.shadowContainer.style.top = "0px";
     this.shadowContainer.style.left = "0px";
+    this.shadowContainer.style.margin = "0px";
+    this.shadowContainer.style.padding = "0px";
     this.shadowRoot = this.shadowContainer.attachShadow({ mode: "open" });
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,6 +15,8 @@ export interface ElementOverlayStyleOptions {
   cursor?: string;
   position?: string;
   zIndex?: string;
+  margin?: string;
+  padding?: string;
 };
 
 export type ElementOverlayOptions = {


### PR DESCRIPTION
If you include this library on a page that has something like

```
div {
    margin: 10px;
}
```

The picker and the shadow dom element are offset by that. Same thing with padding.

You can test this by injecting the library into example.com which does exactly this.

![Screenshot 2023-10-18 at 14 21 06](https://github.com/hmarr/pick-dom-element/assets/12894620/05832575-a315-4918-822b-24999674b1c4)